### PR TITLE
Remove certificate steps from GitHub Actions and add Windows Security notice to README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-# Add permissions block
 permissions:
   contents: write
   issues: write
@@ -31,25 +30,9 @@ jobs:
         pip install -r requirements.txt
         pip install pyinstaller
 
-    # Add certificate creation and signing steps
-    - name: Create Self-signed Certificate
-      run: |
-        $cert = New-SelfSignedCertificate -DnsName "WallpaperAISlideshow" -Type CodeSigning -CertStoreLocation "Cert:\CurrentUser\My"
-        $pwd = ConvertTo-SecureString -String "temp123!" -Force -AsPlainText
-        Export-PfxCertificate -Cert $cert -FilePath "codesign.pfx" -Password $pwd
-      shell: powershell
-
     - name: Build with PyInstaller
       run: |
         pyinstaller wallpaper_ai_slideshow.spec
-        
-    - name: Sign the executable
-      run: |
-        $pwd = ConvertTo-SecureString -String "temp123!" -Force -AsPlainText
-        Import-PfxCertificate -FilePath "codesign.pfx" -CertStoreLocation "Cert:\CurrentUser\My" -Password $pwd
-        $cert = Get-ChildItem -Path Cert:\CurrentUser\My -CodeSigningCert
-        Set-AuthenticodeSignature -FilePath "dist\wallpaper_ai_slideshow\wallpaper_ai_slideshow.exe" -Certificate $cert
-      shell: powershell
 
     - name: Create Release Package
       if: github.ref == 'refs/heads/main'
@@ -66,7 +49,7 @@ jobs:
         name: Release v${{ github.run_number }}
         draft: false
         prerelease: false
-        generate_release_notes: true # Added this option
+        generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Generate and manage beautiful AI-powered wallpapers using DALL-E 3. Transform yo
 ## 📥 Download
 Download the latest version from the [Releases](../../releases) page.
 
+## ⚠️ Windows Security Notice
+When running the application for the first time, you may see a Windows SmartScreen warning saying "Windows protected your PC" or "Unknown Publisher". This is normal for new applications without an expensive code signing certificate.
+
+To run the application:
+1. Click "More info" on the SmartScreen popup
+2. Click "Run anyway"
+
+This warning appears because we're a new, independent developer. The application is safe to use and open source - you can review all the code in this repository.
+
 ## 🔑 Getting OpenAI API Key
 1. Visit [platform.openai.com](https://platform.openai.com)
 2. Sign up or log in to your account


### PR DESCRIPTION
Eliminate unnecessary certificate creation and signing steps from the GitHub Actions workflow. Update the README to inform users about potential Windows SmartScreen warnings when running the application for the first time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "⚠️ Windows Security Notice" section in the README to guide users on bypassing Windows SmartScreen warnings.

- **Chores**
	- Streamlined the build workflow by removing unnecessary certificate creation and signing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->